### PR TITLE
Copied license from README to its own file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Fernando.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Cool project! Thanks for taking the time to open source it.

GitHub tries to detect which license you're using based on the contents of the `LICENSE` file in the root of the repo – it's not smart enough to detect it based off of the README, unfortunately. You can see this in the repo's header:

![Screen Shot 2020-04-21 at 15 07 13](https://user-images.githubusercontent.com/498212/79903951-f042a080-83e1-11ea-811a-306e16770dc6.png)

Compare to a repo I maintain:

![Screen Shot 2020-04-21 at 15 07 23](https://user-images.githubusercontent.com/498212/79903959-f5075480-83e1-11ea-8924-d18386366678.png)

Notice the "MIT" on the right.

This repo metadata is used for search filtering, etc, and a lot of users will use what _GitHub thinks_  is the license while browsing for code. Copying it into its own file should help your repo become more discoverable 👍 